### PR TITLE
Untrack temporary, backup, .out and MacOS directory files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # C extensions
 *.so
+*.out
 
 # Packages
 *.egg
@@ -40,3 +41,9 @@ dist
 .tmp
 .sass-cache
 app/bower_components
+
+# Temporary, backup & MacOS dir
+*~
+*.lock
+*.DS_Store
+*.swp


### PR DESCRIPTION
Sometimes text editors and IDEs produce temporary or backup files during editing. I think these files should not be tracked by git therefore I added them to `.gitignore`.

`.DS_Store` files are used by OS X to store custom attributes of a folder such as the position of icons or the choice of a background image ( http://en.wikipedia.org/wiki/.DS_Store )

`.out` files are sometimes produced as C executables or shared libraries ( http://en.wikipedia.org/wiki/A.out )
