### PR TITLE
Triage workflow: update waterpoint and request together

### DIFF
--- a/app/views/triage.html
+++ b/app/views/triage.html
@@ -17,16 +17,9 @@
         ng-class="{success: request.attribute[k] == waterpoint[k]}">
         <td>{{k}}</td>
         <td>{{waterpoint[k]}}</td>
+        <td>{{request.attribute[k]}}</td>
         <td>
-          <div class="form-group">
-            <input ng-model="request.attribute[k]" type="text" class="form-control">
-          </div>
-        </td>
-        <td>
-          <button type="checkbox" ng-if="request.attribute[k] != waterpoint[k]"
-            ng-click="apply(k)" class="btn btn-success">
-            <span class="glyphicon glyphicon-ok-circle"></span> {{"Apply" | translate }}
-          </button>
+          <input type="checkbox" ng-model="apply[k]" ng-disabled="waterpoint[k] == request.attribute[k]">
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
Previously, waterpoint updates were applied immediately when hitting
"apply" for each attribute and the request was only updated when hitting
"Update report". This is changed to checkboxes for attributes to apply when
the report is updated. The reported value is also no longer editable.
