### PR TITLE
virtualenvwrapper installation for windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,10 @@ To ease development and debugging we suggest you use virtualenv_.
 Install virtualenv_ and virtualenvwrapper (you might need admin rights for this): ::
 
   pip install virtualenv virtualenvwrapper
+  
+For windows only virtualenvwrapper-win_ using pip: ::
+
+  pip install virtualenvwrapper-win
 
 `Set up virtualenvwrapper`_ according to your shell and create a virtualenv: ::
 
@@ -370,3 +374,4 @@ guidelines`_ for further details.
 .. _heroku-buildpack-multi: https://github.com/ddollar/heroku-buildpack-multi
 .. _MongoDB installation instructions: http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
 .. _contributing guidelines: CONTRIBUTING.rst
+.. _virtualenvwrapper-win: https://pypi.python.org/pypi/virtualenvwrapper-win


### PR DESCRIPTION
The command need to stay on the installation guide for windows user to use it
unless other wise it will take them through few links to finally get the command 

That is why I left the window link as well incase during installation you gut stuck somewhere
you can go through the link and see if something is new or not 
