### PR TITLE
Fix TypeError: 'CommandCursor' object is not subscriptable

### DIFF
--- a/taarifa_waterpoints/taarifa_waterpoints.py
+++ b/taarifa_waterpoints/taarifa_waterpoints.py
@@ -133,7 +133,7 @@ def waterpoint_stats_by(field):
     attribute."""
     # FIXME: Direct call to the PyMongo driver, should be abstracted
     resources = app.data.driver.db['resources']
-    return send_response('resources', (resources.aggregate([
+    return send_response('resources', (list(resources.aggregate([
         {"$match": dict(request.args.items())},
         {"$group": {"_id": {field: "$" + field,
                             "status": "$status_group"},
@@ -153,7 +153,7 @@ def waterpoint_stats_by(field):
                       "waterpoints": 1,
                       "population": 1,
                       "count": 1}},
-        {"$sort": {field: 1}}])['result'],))
+        {"$sort": {field: 1}}])),))
 
 
 @app.route('/scripts/<path:filename>')


### PR DESCRIPTION
This PR aims to fix `TypeError: 'CommandCursor' object is not subscriptable` error present with pymongo >= 3.0, which returns [command_cursor](https://pymongo.readthedocs.io/en/stable/api/pymongo/command_cursor.html) object, which is not subscriptable (i.e. has no `result` key) and instead needs to be converted to `list` to be serializable via JSON.

See also https://stackoverflow.com/questions/36515882/command-cursor-object-is-not-subscriptable