### PR TITLE
Install leaflet-maskcanvas which still supports L.TileLayer.MaskCanvas

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -131,7 +131,7 @@
     <script src="bower_components/leaflet-maskcanvas/src/QuadTree.js"></script>
     <script src="bower_components/leaflet-maskcanvas/src/L.TileLayer.MaskCanvas.js"></script>
     <script src="bower_components/leaflet-heatmap/build/heatmap.js"></script>
-    <script src="bower_components/leaflet-heatmap/plugins/leaflet-heatmap.js"></script>
+    <script src="bower_components/leaflet-heatmap/plugins/leaflet-heatmap/leaflet-heatmap.js"></script>
     <script src="scripts/plots.js"></script>
     <script src="scripts/app.js"></script>
     <script src="scripts/services.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "angular-gridster": "~0.9.19",
     "PruneCluster": "~0.9.1",
     "angularjs-geolocation": "~0.1.1",
-    "leaflet-maskcanvas": "git://github.com/domoritz/leaflet-maskcanvas",
+    "leaflet-maskcanvas": "git://github.com/domoritz/leaflet-maskcanvas#819f6b9ecf114b0ab442ab9d1677e37757203c81",
     "leaflet-heatmap": "git://github.com/pa7/heatmap.js#develop",
     "angular-flash": "~0.1.13"
   }


### PR DESCRIPTION
TaarifaWaterpoints uses ancient Leaflet 0.7 which is incompatible with up-to-date version of *leaflet-maskcanvas*, as it provides only `L.GridLayer.MaskCanvas`, but not `L.TileLayer.MaskCanvas` which the application uses.

PR also fixes path for *leaflet-heatmap*.

Making everything work even with up-to-date versions of Leaflet and other libraries would be preferable, but way beyond my expertise, so let's make at least sure the app can be still built using old toolchain even in 2021.